### PR TITLE
New script for linearity test on parameters sensitivities per VAF partition

### DIFF
--- a/scripts/plotting_scripts/plot_linearity_prams_sens_per_ice_stream.py
+++ b/scripts/plotting_scripts/plot_linearity_prams_sens_per_ice_stream.py
@@ -1,3 +1,4 @@
+import sys
 import os
 from pathlib import Path
 import numpy as np
@@ -135,7 +136,7 @@ rcParams['legend.fontsize'] = 5
 rcParams['axes.titlesize'] = 5
 sns.set_context('poster')
 
-label = [r'$\Delta$ $Q^{M}_{T}$ - $Q^{I}_{T}$)',
+label = [r'$\Delta$ ($Q^{M}_{T}$ - $Q^{I}_{T}$)',
          r'$\frac{\partial Q_{M}}{\partial \alpha_{M}} \cdot (\alpha_{M} - \alpha_{I})$ +' +
          r'$\frac{\partial Q_{M}}{\partial \beta_{M}} \cdot (\beta_{M} - \beta_{I})$']
 


### PR DESCRIPTION
New script 

scripts/plotting_scripts/plot_linearity_prams_sens_per_ice_stream.py

which plots: 

```math
\Delta (Q^{M}_{T} - Q^{I}_{T})
```
```math
\frac{\partial Q_{M}}{\partial \alpha_{M}} \cdot (\alpha_{M} - \alpha_{I}) + 
\frac{\partial Q_{M}}{\partial \beta_{M}} \cdot (\beta_{M} - \beta_{I})
```

per VAF partition 