### PR TITLE
Re grid model output for centreline sensitivity plots 

### DIFF
--- a/scripts/plotting_scripts/centreline_plot.py
+++ b/scripts/plotting_scripts/centreline_plot.py
@@ -1,0 +1,380 @@
+import sys
+import salem
+import os
+import argparse
+import glob
+import numpy as np
+from configobj import ConfigObj
+import seaborn as sns
+import geopandas as gpd
+import xarray as xr
+import pyproj
+
+from shapely.geometry import LineString
+import matplotlib.pyplot as plt
+from matplotlib.offsetbox import AnchoredText
+from matplotlib.ticker import FormatStrFormatter
+
+def cumulative_centerline_distance(x, y):
+    """
+    Compute cumulative distance along a centerline given x, y in EPSG:3031.
+    Parameters:
+        x, y: 1D arrays of coordinates (in meters)
+    Returns:
+        cum_dist: 1D array of cumulative distances (in meters)
+    """
+    dx = np.diff(x)
+    dy = np.diff(y)
+    segment_lengths = np.sqrt(dx**2 + dy**2)
+    cum_dist = np.concatenate([[0], np.cumsum(segment_lengths)])
+    return cum_dist
+
+# Load configuration file for more order in paths
+parser = argparse.ArgumentParser()
+parser.add_argument("-conf",
+                    type=str,
+                    default="../../../config.ini",
+                    help="pass config file")
+parser.add_argument("-sub_plot_dir",
+                    type=str,
+                    default="temp",
+                    help="pass sub plot directory to store csv file with output")
+
+args = parser.parse_args()
+config_file = args.conf
+config = ConfigObj(os.path.expanduser(config_file))
+# Define main repository path
+MAIN_PATH = config['main_path']
+fice_tools = config['ficetoos_path']
+sys.path.append(fice_tools)
+
+from ficetools import utils_funcs, velocity
+
+# Paths to output data
+sub_plot_dir = args.sub_plot_dir
+plot_path = os.path.join(MAIN_PATH, 'plots/'+ sub_plot_dir)
+if not os.path.exists(plot_path):
+    os.makedirs(plot_path)
+
+sens_file_paths = glob.glob(os.path.join(plot_path, "*_14.nc"))
+
+centerlines = glob.glob(os.path.join(config['input_files']['centrelines'], '*.shp'))
+
+# Reading netcdf files with re-grided model output
+assert 'THW' in sens_file_paths[0]
+dthw = xr.open_dataset(sens_file_paths[0])
+
+assert 'SPK' in sens_file_paths[1]
+dspk = xr.open_dataset(sens_file_paths[1])
+
+assert 'PIG' in sens_file_paths[2]
+dpig = xr.open_dataset(sens_file_paths[2])
+
+# Reading manually delineated centrelines.
+# Some of these centrelines are read from last point to
+# the beginning of the calving front tos coordinates need to
+# be flip
+assert "pope" in centerlines[0]
+pope = gpd.read_file(centerlines[0])
+pope_line = pope.geometry.iloc[0]
+reversed_coords = list(pope_line.coords)[::-1]
+reversed_line = LineString(reversed_coords)
+pope.geometry.iloc[0] = reversed_line
+
+assert "smith" in centerlines[1]
+smith = gpd.read_file(centerlines[1])
+smith_line = smith.geometry.iloc[0]
+reversed_coords = list(smith_line.coords)[::-1]
+reversed_line = LineString(reversed_coords)
+smith.geometry.iloc[0] = reversed_line
+
+assert "kohler" in centerlines[2]
+kohler = gpd.read_file(centerlines[2])
+kohler_line = kohler.geometry.iloc[0]
+reversed_coords = list(kohler_line.coords)[::-1]
+reversed_line = LineString(reversed_coords)
+kohler.geometry.iloc[0] = reversed_line
+
+assert "pig" in centerlines[3]
+pig = gpd.read_file(centerlines[3])
+
+assert "thw" in centerlines[4]
+thw = gpd.read_file(centerlines[4])
+
+assert "hay" in centerlines[5]
+hay = gpd.read_file(centerlines[5])
+hay_line = hay.geometry.iloc[0]
+reversed_coords = list(hay_line.coords)[::-1]
+reversed_line = LineString(reversed_coords)
+hay.geometry.iloc[0] = reversed_line
+
+## Reading mask of parts of the icestream grounded and
+## above floatation
+model_gnd_10 = xr.open_dataset(os.path.join(plot_path, 'model_gl_10.nc'))
+model_gnd_40 = xr.open_dataset(os.path.join(plot_path, 'model_gl_40.nc'))
+
+# If more years are required by reviewers we will
+# put this as argparse arguments
+# Years and num_sens code for simulations
+n_sens = [3, 14]
+years = [10, 40]
+
+# We interpolate model output to
+# points along a centreline every 100 meters
+step = 100
+
+pig_sens_3, pig_sens_14 = utils_funcs.interp_model_output_to_centreline(dpig,
+                                                                        pig,
+                                                                        n_sens=n_sens,
+                                                                        step=step)
+
+thw_sens_3, thw_sens_14 = utils_funcs.interp_model_output_to_centreline(dthw,
+                                                                        thw,
+                                                                        n_sens=n_sens,
+                                                                        step=step)
+
+hay_sens_3, hay_sens_14 = utils_funcs.interp_model_output_to_centreline(dthw,
+                                                                        hay,
+                                                                        n_sens=n_sens,
+                                                                        step=step)
+
+pope_sens_3, pope_sens_14 = utils_funcs.interp_model_output_to_centreline(dspk,
+                                                                          pope,
+                                                                          n_sens=n_sens,
+                                                                          step=step)
+
+smith_sens_3, smith_sens_14 = utils_funcs.interp_model_output_to_centreline(dspk,
+                                                                            smith,
+                                                                            n_sens=n_sens,
+                                                                            step=step)
+
+kohler_sens_3, kohler_sens_14 = utils_funcs.interp_model_output_to_centreline(dspk,
+                                                                              kohler,
+                                                                              n_sens=n_sens,
+                                                                              step=step)
+
+## We interpolate teh model mask to the centreline
+
+mask_pig_3, mask_pig_14 = utils_funcs.interp_model_mask_to_centreline(model_gnd_10,
+                                                                      model_gnd_40,
+                                                                      pig,
+                                                                      years=years,
+                                                                      step=step)
+
+mask_thw_3, mask_thw_14 = utils_funcs.interp_model_mask_to_centreline(model_gnd_10,
+                                                                      model_gnd_40,
+                                                                      thw,
+                                                                      years=years,
+                                                                      step=step)
+
+mask_hay_3, mask_hay_14 = utils_funcs.interp_model_mask_to_centreline(model_gnd_10,
+                                                                      model_gnd_40,
+                                                                      hay,
+                                                                      years=years,
+                                                                      step=step)
+
+mask_pope_3, mask_pope_14 = utils_funcs.interp_model_mask_to_centreline(model_gnd_10,
+                                                                        model_gnd_40,
+                                                                        pope,
+                                                                        years=years,
+                                                                        step=step)
+
+mask_smith_3, mask_smith_14 = utils_funcs.interp_model_mask_to_centreline(model_gnd_10,
+                                                                          model_gnd_40,
+                                                                          smith,
+                                                                          years=years,
+                                                                          step=step)
+
+mask_kohler_3, mask_kohler_14 = utils_funcs.interp_model_mask_to_centreline(model_gnd_10,
+                                                                            model_gnd_40,
+                                                                            kohler,
+                                                                            years=years,
+                                                                            step=step)
+
+label_year10 = 'Year 9 '+ r'$\frac{\partial Q}{\partial\hat{p}}$'
+label_year40 = 'Year 40 '+ r'$\frac{\partial Q}{\partial\hat{p}}$'
+
+label_floating_10 = 'Floating part Year 9'
+label_floating_40 = 'Floating part Year 40'
+
+r = 0.9
+color_palette = sns.color_palette("deep")
+
+# Create figure and axes in a 2x4 grid
+fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(14 * r, 6 * r))
+
+ax0 = axes[0, 0]
+pigx = pig_sens_14.x.data
+pigy = pig_sens_14.y.data
+x = pig_sens_14.points
+distance_pig = cumulative_centerline_distance(pigx, pigy)
+tick_positions = np.arange(0, len(x), 500)
+tick_labels = [np.round(distance_pig[i], decimals=0) for i in tick_positions]
+pig_sens_14.plot(ax=ax0, label='')
+pig_sens_3.plot(ax=ax0, label='')
+ax0.fill_between(x, pig_sens_3, where=(mask_pig_3 == 0.0),  facecolor='none', edgecolor='gray', hatch='///', alpha=0.5, label='')
+ax0.fill_between(x, pig_sens_14, where=(mask_pig_14 == 0.0), color='gray', alpha=0.5, label='')
+ax0.set_xticks(tick_positions)
+ax0.set_xticklabels(tick_labels)
+at = AnchoredText('a', prop=dict(size=12), frameon=True, loc='lower left')
+ax0.add_artist(at)
+ax0.set_title('Pine Island', fontsize=12)
+
+ax1 = axes[0, 1]
+thwx = thw_sens_14.x.data
+thwy = thw_sens_14.y.data
+distance_thw = cumulative_centerline_distance(thwx, thwy)
+x = thw_sens_14.points
+tick_positions = np.arange(0, len(x), 600)
+tick_labels = [np.round(distance_thw[i], decimals=0) for i in tick_positions]
+thw_sens_14.plot(ax=ax1, label='')
+thw_sens_3.plot(ax=ax1, label='')
+ax1.fill_between(x, thw_sens_3, where=(mask_thw_3 == 0.0),  facecolor='none', edgecolor='gray', hatch='///', alpha=0.5, label='')
+ax1.fill_between(x, thw_sens_14, where=(mask_thw_14 == 0.0), color='gray', alpha=0.5, label='')
+ax1.set_xticks(tick_positions)
+ax1.set_xticklabels(tick_labels)
+at = AnchoredText('b', prop=dict(size=12), frameon=True, loc='lower left')
+ax1.add_artist(at)
+ax1.set_title('Thwaites', fontsize=12)
+
+ax2 = axes[0, 2]
+hayx = hay_sens_14.x.data
+hayy = hay_sens_14.y.data
+distance_hay = cumulative_centerline_distance(hayx, hayy)
+x = hay_sens_14.points
+tick_positions = np.arange(0, len(x), 300)
+tick_labels = [np.round(distance_hay[i], decimals=0) for i in tick_positions]
+hay_sens_14.plot(ax=ax2, label='')
+hay_sens_3.plot(ax=ax2, label='')
+ax2.fill_between(x, hay_sens_3, where=(mask_hay_3 == 0.0),  facecolor='none', edgecolor='gray', hatch='///', alpha=0.3, label='')
+ax2.fill_between(x, hay_sens_14, where=(mask_hay_14 == 0.0), color='gray', alpha=0.5, label='')
+ax2.set_xticks(tick_positions)
+ax2.set_xticklabels(tick_labels)
+at = AnchoredText('c', prop=dict(size=12), frameon=True, loc='lower left')
+ax2.add_artist(at)
+ax2.set_title('Haynes', fontsize=12)
+
+ax3 = axes[1, 0]
+x = pope_sens_14.points
+popex = pope_sens_14.x.data
+popey = pope_sens_14.y.data
+distance_pope = cumulative_centerline_distance(popex, popey)
+tick_positions = np.arange(0, len(x), 100)
+tick_labels = [np.round(distance_pope[i], decimals=0) for i in tick_positions]
+pope_sens_14.plot(ax=ax3, label='')
+pope_sens_3.plot(ax=ax3, label='')
+ax3.fill_between(x, pope_sens_3, where=(mask_pope_3 == 0.0),  facecolor='none', edgecolor='gray', hatch='///', alpha=0.3, label='')
+ax3.fill_between(x, pope_sens_14, where=(mask_pope_14 == 0.0), color='gray', alpha=0.5, label='')
+ax3.set_xticks(tick_positions)
+ax3.set_xticklabels(tick_labels)
+at = AnchoredText('d', prop=dict(size=12), frameon=True, loc='lower left')
+ax3.add_artist(at)
+ax3.set_title('Pope', fontsize=12)
+
+ax4 = axes[1, 1]
+x = smith_sens_14.points
+smithx = smith_sens_14.x.data
+smithy = smith_sens_14.y.data
+distance_smith = cumulative_centerline_distance(smithx, smithy)
+tick_positions = np.arange(0, len(x), 200)
+tick_labels = [np.round(distance_smith[i], decimals=0) for i in tick_positions]
+smith_sens_14.plot(ax=ax4, label='')
+smith_sens_3.plot(ax=ax4, label='')
+ax4.fill_between(x, smith_sens_3, where=(mask_smith_3 == 0.0),  facecolor='none', edgecolor='gray', hatch='///', alpha=0.3, label='')
+ax4.fill_between(x, smith_sens_14, where=(mask_smith_14 == 0.0), color='gray', alpha=0.5, label='')
+ax4.set_xticks(tick_positions)
+ax4.set_xticklabels(tick_labels)
+at = AnchoredText('e', prop=dict(size=12), frameon=True, loc='lower left')
+ax4.add_artist(at)
+ax4.set_title('Smith east', fontsize=12)
+
+ax5 = axes[1, 2]
+x = kohler_sens_14.points
+kohlerx = kohler_sens_14.x.data
+kohlery = kohler_sens_14.y.data
+distance_kohler = cumulative_centerline_distance(kohlerx, kohlery)
+tick_positions = np.arange(0, len(x), 200)
+tick_labels = [np.round(distance_kohler[i], decimals=0) for i in tick_positions]
+kohler_sens_14.plot(ax=ax5, label=label_year40)
+kohler_sens_3.plot(ax=ax5, label=label_year10)
+ax5.fill_between(x, kohler_sens_3, where=(mask_kohler_3 == 0.0),  facecolor='none',
+                 edgecolor='gray', hatch='///', alpha=0.3, label=label_floating_10)
+ax5.fill_between(x, kohler_sens_14, where=(mask_kohler_14 == 0.0), color='gray',
+                 alpha=0.5, label=label_floating_40)
+ax5.set_xticks(tick_positions)
+ax5.set_xticklabels(tick_labels)
+at = AnchoredText('f', prop=dict(size=12), frameon=True, loc='lower left')
+ax5.add_artist(at)
+ax5.set_title('Kohler west', fontsize=12)
+
+ax5.legend(loc='lower right')
+
+for row in range(2):
+    for col in range(3):
+        ax = axes[row, col]
+        ax.xaxis.set_major_formatter(FormatStrFormatter('%d'))
+        ax.set_xlabel('Distance (m)')
+        ax.set_ylabel(r'log(10) $\frac{\partial Q}{\partial\hat{p}}$', rotation=360, fontsize=12, labelpad=40)
+        if col != 0:
+            ax.set_ylabel('')
+            ax.set_yticklabels([])
+            ax.set_yticks([])
+
+file_plot_name = 'centreline_sensitivities.png'
+
+fig_save_path = os.path.join(plot_path, file_plot_name)
+plt.savefig(fig_save_path, bbox_inches='tight', dpi=150)
+
+# Making the map with centrelines
+
+vel_obs = utils_funcs.find_measures_file(2013,
+                                         config['input_files']['measures_cloud'])
+ase_bbox = {}
+for key in config['mesh_extent'].keys():
+    ase_bbox[key] = np.float64(config['mesh_extent'][key])
+
+gv = velocity.define_salem_grid_from_measures(vel_obs, ase_bbox)
+proj_gnd = pyproj.Proj('EPSG:3031')
+gv = salem.Grid(nxny=(520, 710), dxdy=(gv.dx, gv.dy),
+                x0y0=(-1702500.0, 500.0), proj=proj_gnd)
+
+shp = gpd.read_file(config['input_files']['ice_boundaries'])
+shp_sel = shp.loc[[62, 63, 64, 137, 138, 139]]
+assert shp_sel is not None
+shp_sel.crs = gv.proj.crs
+proj = pyproj.Proj('EPSG:3031')
+
+file_name = 'MEaSUREs_mosaic_in_itslive_grid_croped.nc'
+dv = xr.open_dataset(os.path.join(plot_path, file_name))
+vv = (dv.vx**2 + dv.vy**2)**0.5
+
+minv = 0
+maxv = 2000
+levels = np.linspace(minv, maxv, 200)
+ticks = np.linspace(minv, maxv, 3)
+
+
+fig, axes = plt.subplots(figsize=(6, 8))
+smap = salem.Map(gv, countries=False)
+x_n, y_n = smap.grid.transform(dv.x, dv.y,
+                               crs=gv.proj)
+c = axes.contourf(x_n, y_n, vv.data, levels=levels, extend="both")
+
+smap.set_shapefile(shp_sel, linewidth=2, edgecolor=sns.xkcd_rgb["grey"])
+
+smap.set_shapefile(pig, linewidth=2)
+smap.set_shapefile(thw, linewidth=2)
+smap.set_shapefile(hay, linewidth=2)
+smap.set_shapefile(pope, linewidth=2)
+smap.set_shapefile(smith, linewidth=2)
+smap.set_shapefile(kohler, linewidth=2)
+
+smap.set_lonlat_contours(add_ytick_labels=False, xinterval=10, yinterval=2, linewidths=1.5,
+                          linestyles='-', colors='grey', add_tick_labels=False)
+smap.set_scale_bar(location=(0.87, 0.04), add_bbox=True)
+smap.visualize(ax=axes, orientation='horizontal', addcbar=False)
+
+file_plot_name = 'centrelines_map.png'
+
+fig_save_path = os.path.join(plot_path, file_plot_name)
+plt.savefig(fig_save_path, bbox_inches='tight', dpi=150)

--- a/scripts/plotting_scripts/centreline_plot.py
+++ b/scripts/plotting_scripts/centreline_plot.py
@@ -201,14 +201,14 @@ r = 0.9
 color_palette = sns.color_palette("deep")
 
 # Create figure and axes in a 2x4 grid
-fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(14 * r, 6 * r))
+fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(14 * r, 6 * r), gridspec_kw={'hspace': 0.5})
 
 ax0 = axes[0, 0]
 pigx = pig_sens_14.x.data
 pigy = pig_sens_14.y.data
 x = pig_sens_14.points
 distance_pig = cumulative_centerline_distance(pigx, pigy)
-tick_positions = np.arange(0, len(x), 500)
+tick_positions = np.arange(0, len(x), 1000)
 tick_labels = [np.round(distance_pig[i], decimals=0) for i in tick_positions]
 pig_sens_14.plot(ax=ax0, label='')
 pig_sens_3.plot(ax=ax0, label='')
@@ -225,7 +225,7 @@ thwx = thw_sens_14.x.data
 thwy = thw_sens_14.y.data
 distance_thw = cumulative_centerline_distance(thwx, thwy)
 x = thw_sens_14.points
-tick_positions = np.arange(0, len(x), 600)
+tick_positions = np.arange(0, len(x), 1000)
 tick_labels = [np.round(distance_thw[i], decimals=0) for i in tick_positions]
 thw_sens_14.plot(ax=ax1, label='')
 thw_sens_3.plot(ax=ax1, label='')
@@ -293,7 +293,7 @@ x = kohler_sens_14.points
 kohlerx = kohler_sens_14.x.data
 kohlery = kohler_sens_14.y.data
 distance_kohler = cumulative_centerline_distance(kohlerx, kohlery)
-tick_positions = np.arange(0, len(x), 200)
+tick_positions = np.arange(0, len(x), 500)
 tick_labels = [np.round(distance_kohler[i], decimals=0) for i in tick_positions]
 kohler_sens_14.plot(ax=ax5, label=label_year40)
 kohler_sens_3.plot(ax=ax5, label=label_year10)

--- a/scripts/plotting_scripts/plot_ASE_params_sens_per_icestream.py
+++ b/scripts/plotting_scripts/plot_ASE_params_sens_per_icestream.py
@@ -194,6 +194,9 @@ shp_lake = gpd.read_file(config['input_files']['thw_lake'])
 gnd_line = gpd.read_file(config['input_files']['rignot_thw'])
 gnd_rig = gnd_line.to_crs(proj_gnd.crs).reset_index()
 
+model_gnd_10 = gpd.read_file(config['input_files']['model_gl_10'])
+model_gnd_40 = gpd.read_file(config['input_files']['model_gl_40'])
+
 ## ALPHA PLOT #####################################################
 fig1 = plt.figure(figsize=(10*r, 10*r))#, constrained_layout=True)
 spec = gridspec.GridSpec(1, 2, wspace=0.1, hspace=0.3)
@@ -230,6 +233,12 @@ for g, geo in enumerate(shp_lake.geometry):
                       linewidth=1.0,
                       alpha=0.1,
                       facecolor='white', edgecolor='white',
+                      crs=gv.proj)
+
+for g, geo in enumerate(model_gnd_10.geometry):
+    smap.set_geometry(model_gnd_10.loc[g].geometry,
+                      linewidth=1.0,
+                      color=sns.xkcd_rgb["ocean blue"],
                       crs=gv.proj)
 
 smap.set_lonlat_contours(add_ytick_labels=False, xinterval=10, yinterval=2, linewidths=1.5,
@@ -280,6 +289,12 @@ for g, geo in enumerate(shp_lake.geometry):
                       facecolor='white', edgecolor='white',
                       crs=gv.proj)
 
+for g, geo in enumerate(model_gnd_40.geometry):
+    smap.set_geometry(model_gnd_40.loc[g].geometry,
+                      linewidth=1.0,
+                      color=sns.xkcd_rgb["ocean blue"],
+                      crs=gv.proj)
+
 smap.set_lonlat_contours(add_ytick_labels=False, xinterval=10, yinterval=2, linewidths=1.5,
                           linestyles='-', colors='grey', add_tick_labels=False)
 smap.set_scale_bar(location=(0.87, 0.04), add_bbox=True)
@@ -318,6 +333,19 @@ smap.set_vmax(maxv)
 smap.set_extend('both')
 smap.set_cmap(cmap_sen)
 smap.set_shapefile(shp_sel, linewidth=1.0, edgecolor=sns.xkcd_rgb["grey"])
+
+for g, geo in enumerate(data.geometry):
+    smap.set_geometry(data.loc[g].geometry,
+                      linewidth=2,
+                      color=sns.xkcd_rgb["white"],
+                      alpha=0.3, crs=gv.proj)
+
+for g, geo in enumerate(model_gnd_10.geometry):
+    smap.set_geometry(model_gnd_10.loc[g].geometry,
+                      linewidth=1.0,
+                      color=sns.xkcd_rgb["ocean blue"],
+                      crs=gv.proj)
+
 smap.set_lonlat_contours(add_ytick_labels=False, xinterval=10, yinterval=2, linewidths=1.5,
                           linestyles='-', colors='grey', add_tick_labels=False)
 smap.set_scale_bar(location=(0.87, 0.04), add_bbox=True)
@@ -344,6 +372,19 @@ smap.set_vmax(maxv)
 smap.set_extend('both')
 smap.set_cmap(cmap_sen)
 smap.set_shapefile(shp_sel, linewidth=1.0, edgecolor=sns.xkcd_rgb["grey"])
+
+for g, geo in enumerate(data.geometry):
+    smap.set_geometry(data.loc[g].geometry,
+                      linewidth=2,
+                      color=sns.xkcd_rgb["white"],
+                      alpha=0.3, crs=gv.proj)
+
+for g, geo in enumerate(model_gnd_40.geometry):
+    smap.set_geometry(model_gnd_40.loc[g].geometry,
+                      linewidth=1.0,
+                      color=sns.xkcd_rgb["ocean blue"],
+                      crs=gv.proj)
+
 smap.set_lonlat_contours(add_ytick_labels=False, xinterval=10, yinterval=2, linewidths=1.5,
                           linestyles='-', colors='grey', add_tick_labels=False)
 smap.set_scale_bar(location=(0.87, 0.04), add_bbox=True)

--- a/scripts/plotting_scripts/plot_ASE_vel_sens_per_icestream.py
+++ b/scripts/plotting_scripts/plot_ASE_vel_sens_per_icestream.py
@@ -257,7 +257,7 @@ if args.save_regrid_output:
 
         v = nc.createVariable('dQ_dM_' + str(start), 'f4', ('y', 'x'))
         v.units = 'm'
-        v.long_name = 'dQ/dObs magnitude as log(10)' + str(end)
+        v.long_name = 'dQ/dObs magnitude as log(10)' + str(start)
         v[:] = mag_vector_3_regrid
 
         v = nc.createVariable('dQ_dM_' + str(end), 'f4', ('y', 'x'))

--- a/scripts/plotting_scripts/plot_intro_figure.py
+++ b/scripts/plotting_scripts/plot_intro_figure.py
@@ -192,14 +192,14 @@ smap = salem.Map(gv, countries=False)
 
 x_n, y_n = smap.grid.transform(x, y,
                               crs=gv.proj)
-smap.set_lonlat_contours(xinterval=2.0, yinterval=1.0, add_tick_labels=True, linewidths=1.5)
-smap.set_scale_bar(length=100000)
 minv = 0
 maxv = 3000
 levels = np.linspace(minv,maxv,200)
 ticks = np.linspace(minv,maxv,3)
 c = ax0.tricontourf(x_n, y_n, t, U_itlive, levels = levels, cmap='viridis', extend="both")
-smap.set_lonlat_contours(xinterval=2.0, yinterval=1.0, add_tick_labels=True, linewidths=1.5)
+smap.set_lonlat_contours(add_ytick_labels=False, xinterval=10, yinterval=2, linewidths=1.5,
+                              linestyles='-', colors='grey', add_tick_labels=False)
+smap.set_scale_bar(location=(0.87, 0.04), add_bbox=True)
 smap.set_vmin(minv)
 smap.set_vmax(maxv)
 smap.set_extend('both')
@@ -217,7 +217,8 @@ cax = divider.append_axes("bottom", size="5%", pad=0.5)
 smap = salem.Map(gv, countries=False)
 
 c = ax1.tricontourf(x_n, y_n, t, uv_live, levels = levels, cmap='viridis', extend="both")
-smap.set_lonlat_contours(xinterval=2.0, yinterval=1.0, add_tick_labels=True, linewidths=1.5)
+smap.set_lonlat_contours(add_ytick_labels=False, xinterval=10, yinterval=2, linewidths=1.5,
+                              linestyles='-', colors='grey', add_tick_labels=False)
 smap.set_vmin(minv)
 smap.set_vmax(maxv)
 smap.set_extend('both')
@@ -241,10 +242,16 @@ maxv = 40
 levels = np.linspace(minv,maxv,200)
 ticks = np.linspace(minv,maxv,3)
 c = ax2.tricontourf(x_n, y_n, t, alpha_v_il, levels=levels, cmap=cmap_params_alpha, extend="both")
+smap.set_lonlat_contours(add_ytick_labels=False, xinterval=10, yinterval=2, linewidths=1.5,
+                              linestyles='-', colors='grey', add_tick_labels=False)
 smap.set_cmap(cmap_params_alpha)
 smap.set_vmin(minv)
 smap.set_vmax(maxv)
 smap.set_extend('both')
+for g, geo in enumerate(data.geometry):
+    smap.set_geometry(data.loc[g].geometry,
+                      linewidth=2.0,
+                      color=sns.xkcd_rgb["black"], crs=gv.proj)
 smap.visualize(ax=ax2, orientation='horizontal', addcbar=False)
 cbar = smap.colorbarbase(cax=cax, orientation="horizontal",
                          label='Sliding parameter \n [m$^{-1/6}$ yr$^{1/6}$ Pa$^{1/2}$]')
@@ -263,6 +270,8 @@ maxv = 800
 levels = np.linspace(minv,maxv,200)
 ticks = np.linspace(minv,maxv,3)
 c = ax3.tricontourf(x_n, y_n, t, beta_v_il, levels=levels, cmap=cmap_params_bglen, extend="both")
+smap.set_lonlat_contours(add_ytick_labels=False, xinterval=10, yinterval=2, linewidths=1.5,
+                              linestyles='-', colors='grey', add_tick_labels=False)
 smap.set_cmap(cmap_params_bglen)
 smap.set_vmin(minv)
 smap.set_vmax(maxv)

--- a/scripts/plotting_scripts/plot_intro_figure.py
+++ b/scripts/plotting_scripts/plot_intro_figure.py
@@ -172,8 +172,10 @@ rcParams['xtick.labelsize'] = 18
 rcParams['ytick.labelsize'] = 18
 rcParams['axes.titlesize'] = 18
 
-cmap_vel=sns.diverging_palette(220, 20, as_cmap=True)
-cmap_params_alpha = colormaps.get_cmap('YlOrBr')
+cmap_vel=sns.color_palette("Spectral_r", as_cmap=True)
+#cmap_params_alpha = colormaps.get_cmap('YlOrBr')
+cmap_params_alpha = colormaps.get_cmap('RdYlBu_r')
+#cmap_params_bglen = colormaps.get_cmap('cubehelix')
 cmap_params_bglen = colormaps.get_cmap('YlGnBu')
 
 # Now plotting
@@ -193,17 +195,17 @@ smap = salem.Map(gv, countries=False)
 x_n, y_n = smap.grid.transform(x, y,
                               crs=gv.proj)
 minv = 0
-maxv = 3000
+maxv = 800
 levels = np.linspace(minv,maxv,200)
 ticks = np.linspace(minv,maxv,3)
-c = ax0.tricontourf(x_n, y_n, t, U_itlive, levels = levels, cmap='viridis', extend="both")
+c = ax0.tricontourf(x_n, y_n, t, U_itlive, levels = levels, cmap=cmap_vel, extend="both")
 smap.set_lonlat_contours(add_ytick_labels=False, xinterval=10, yinterval=2, linewidths=1.5,
                               linestyles='-', colors='grey', add_tick_labels=False)
 smap.set_scale_bar(location=(0.87, 0.04), add_bbox=True)
 smap.set_vmin(minv)
 smap.set_vmax(maxv)
 smap.set_extend('both')
-smap.set_cmap('viridis')
+smap.set_cmap(cmap_vel)
 smap.visualize(ax=ax0, orientation='horizontal', addcbar=False)
 cbar = smap.colorbarbase(cax=cax, orientation="horizontal",
                          label='speed [m. $yr^{-1}$]')
@@ -216,13 +218,13 @@ divider = make_axes_locatable(ax1)
 cax = divider.append_axes("bottom", size="5%", pad=0.5)
 smap = salem.Map(gv, countries=False)
 
-c = ax1.tricontourf(x_n, y_n, t, uv_live, levels = levels, cmap='viridis', extend="both")
+c = ax1.tricontourf(x_n, y_n, t, uv_live, levels = levels, cmap=cmap_vel, extend="both")
 smap.set_lonlat_contours(add_ytick_labels=False, xinterval=10, yinterval=2, linewidths=1.5,
                               linestyles='-', colors='grey', add_tick_labels=False)
 smap.set_vmin(minv)
 smap.set_vmax(maxv)
 smap.set_extend('both')
-smap.set_cmap('viridis')
+smap.set_cmap(cmap_vel)
 smap.visualize(ax=ax1, orientation='horizontal', addcbar=False)
 cbar = smap.colorbarbase(cax=cax, orientation="horizontal",
                          label='speed [m. $yr^{-1}$]')
@@ -282,8 +284,8 @@ cbar = smap.colorbarbase(cax=cax, orientation="horizontal",
 at = AnchoredText('d', prop=dict(size=18), frameon=True, loc='upper right')
 ax3.add_artist(at)
 
-ax1.title.set_text(r'Model speed')
-ax2.title.set_text(r'Observed speed')
+ax0.title.set_text(r'Model speed')
+ax1.title.set_text(r'Observed speed MEaSUREs')
 ax2.title.set_text(r'$\alpha_{MEaSUREs}$')
 ax3.title.set_text(r'$\beta_{MEaSUREs}$')
 

--- a/scripts/plotting_scripts/plot_intro_figure.py
+++ b/scripts/plotting_scripts/plot_intro_figure.py
@@ -2,6 +2,7 @@ import sys
 import salem
 import pyproj
 import xarray as xr
+import geopandas as gpd
 import matplotlib.pyplot as plt
 import seaborn as sns
 import os
@@ -27,7 +28,7 @@ parser.add_argument("-conf",
                     type=str,
                     default="../../../config.ini",
                     help="pass config file")
-parser.add_argument("-toml_path_i",
+parser.add_argument("-toml_path",
                     type=str,
                     default="",
                     help="pass .toml file")
@@ -35,6 +36,14 @@ parser.add_argument("-sub_plot_dir",
                     type=str,
                     default="temp",
                     help="pass sub plot directory to store the plots")
+parser.add_argument("-plot_name",
+                    type=str,
+                    default="temp",
+                    help="pass plot name e.g. measures")
+parser.add_argument("-plot_domain",
+                    action="store_true",
+                    help="If this is specify "
+                         "the we make a plot too.")
 
 args = parser.parse_args()
 config_file = args.conf
@@ -54,7 +63,7 @@ if not os.path.exists(plot_path):
 from ficetools import utils_funcs, graphics, velocity
 from ficetools.backend import FunctionSpace, VectorFunctionSpace, Function, project
 
-toml_config1 = args.toml_path_i
+toml_config1 = args.toml_path
 
 params_il = conf.ConfigParser(toml_config1)
 
@@ -135,17 +144,28 @@ alpha_v_il = alpha_ilp.compute_vertex_values(mesh_in)
 beta_ilp = project(beta_il, M)
 beta_v_il = beta_ilp.compute_vertex_values(mesh_in)
 
-vel_obs = config['input_files']['measures_cloud']
-
+vel_obs = utils_funcs.find_measures_file(2013,
+                                         config['input_files']['measures_cloud'])
 ase_bbox = {}
 for key in config['mesh_extent'].keys():
     ase_bbox[key] = np.float64(config['mesh_extent'][key])
 
-# Any measures should do ... 
-full_vel_path = os.path.join(vel_obs, 'Antarctica_ice_velocity_2013_2014_1km_v01.nc')
-print(full_vel_path)
+gv = velocity.define_salem_grid_from_measures(vel_obs, ase_bbox)
 
-gv = velocity.define_salem_grid_from_measures(full_vel_path, ase_bbox)
+# Right Projection! TODO: We need to add this to every plot!
+proj_gnd = pyproj.Proj('EPSG:3031')
+gv = salem.Grid(nxny=(520, 710), dxdy=(gv.dx, gv.dy),
+                x0y0=(-1702500.0, 500.0), proj=proj_gnd)
+
+# Gathering all the shapefiles
+shp = gpd.read_file(config['input_files']['ice_boundaries'])
+shp_sel = shp.loc[[62, 63, 64, 138, 137, 138, 139]]
+shp_sel.crs = gv.proj.crs
+
+# Grounding line for other icestreams
+gdf = gpd.read_file(config['input_files']['grounding_line'])
+ase_ground = gdf[220:235]
+data = ase_ground.to_crs(proj_gnd.crs).reset_index()
 
 rcParams['axes.labelsize'] = 18
 rcParams['xtick.labelsize'] = 18
@@ -163,19 +183,30 @@ tick_options = {'axis':'both','which':'both','bottom':False,
      'top':False,'left':False,'right':False,'labelleft':False, 'labelbottom':False}
 
 fig1 = plt.figure(figsize=(16*r, 6*r))#, constrained_layout=True)
-spec = gridspec.GridSpec(1, 3, wspace=0.05)
+spec = gridspec.GridSpec(1, 2, wspace=0.05)
 
 ax0 = plt.subplot(spec[0])
-ax0.set_aspect('equal')
-
+divider = make_axes_locatable(ax0)
+cax = divider.append_axes("bottom", size="5%", pad=0.5)
 smap = salem.Map(gv, countries=False)
 
 x_n, y_n = smap.grid.transform(x, y,
                               crs=gv.proj)
 smap.set_lonlat_contours(xinterval=2.0, yinterval=1.0, add_tick_labels=True, linewidths=1.5)
 smap.set_scale_bar(length=100000)
-c = ax0.triplot(x_n, y_n, t, color=sns.xkcd_rgb["black"], lw=0.2)
+minv = 0
+maxv = 3000
+levels = np.linspace(minv,maxv,200)
+ticks = np.linspace(minv,maxv,3)
+c = ax0.tricontourf(x_n, y_n, t, U_itlive, levels = levels, cmap='viridis', extend="both")
+smap.set_lonlat_contours(xinterval=2.0, yinterval=1.0, add_tick_labels=True, linewidths=1.5)
+smap.set_vmin(minv)
+smap.set_vmax(maxv)
+smap.set_extend('both')
+smap.set_cmap('viridis')
 smap.visualize(ax=ax0, orientation='horizontal', addcbar=False)
+cbar = smap.colorbarbase(cax=cax, orientation="horizontal",
+                         label='speed [m. $yr^{-1}$]')
 at = AnchoredText('a', prop=dict(size=18), frameon=True, loc='upper left')
 ax0.add_artist(at)
 
@@ -184,11 +215,8 @@ ax1 = plt.subplot(spec[1])
 divider = make_axes_locatable(ax1)
 cax = divider.append_axes("bottom", size="5%", pad=0.5)
 smap = salem.Map(gv, countries=False)
-minv = 0
-maxv = 3000
-levels = np.linspace(minv,maxv,200)
-ticks = np.linspace(minv,maxv,3)
-c = ax1.tricontourf(x_n, y_n, t, U_itlive, levels = levels, cmap='viridis', extend="both")
+
+c = ax1.tricontourf(x_n, y_n, t, uv_obs_live, levels = levels, cmap='viridis', extend="both")
 smap.set_lonlat_contours(xinterval=2.0, yinterval=1.0, add_tick_labels=True, linewidths=1.5)
 smap.set_vmin(minv)
 smap.set_vmax(maxv)
@@ -196,7 +224,7 @@ smap.set_extend('both')
 smap.set_cmap('viridis')
 smap.visualize(ax=ax1, orientation='horizontal', addcbar=False)
 cbar = smap.colorbarbase(cax=cax, orientation="horizontal",
-                         label='model velocity [m. $yr^{-1}$]')
+                         label='speed [m. $yr^{-1}$]')
 at = AnchoredText('b', prop=dict(size=18), frameon=True, loc='upper right')
 ax1.add_artist(at)
 
@@ -206,59 +234,26 @@ ax2.set_aspect('equal')
 divider = make_axes_locatable(ax2)
 cax = divider.append_axes("bottom", size="5%", pad=0.5)
 smap = salem.Map(gv, countries=False)
-minv = -150
-maxv = 150
-levels = np.linspace(minv,maxv,200)
-ticks = np.linspace(minv,maxv,3)
-c = ax2.tricontourf(x_n, y_n, t, uv_live-U_itlive, levels = levels, cmap=cmap_vel, extend="both")
-smap.set_lonlat_contours(xinterval=2.0, yinterval=1.0, add_tick_labels=True, linewidths=1.5)
-smap.set_vmin(minv)
-smap.set_vmax(maxv)
-smap.set_extend('both')
-smap.set_cmap(cmap_vel)
-smap.visualize(ax=ax2, orientation='horizontal', addcbar=False)
-cbar = smap.colorbarbase(cax=cax, orientation="horizontal",
-                         label='velocity differences [m. $yr^{-1}$]')
-at = AnchoredText('c', prop=dict(size=18), frameon=True, loc='upper right')
-ax2.add_artist(at)
-
-ax0.title.set_text('FEniCS_ice model domain')
-ax1.title.set_text('FEniCS_ice initial velocity')
-ax2.title.set_text('MEaSUREs - Model velocities')
-
-plt.tight_layout()
-plt.savefig(os.path.join(plot_path, 'ase_model_obs_velocities.png'),
-            bbox_inches='tight', dpi=150)
-
-
-fig2 = plt.figure(figsize=(8*r, 6*r))#, constrained_layout=True)
-spec = gridspec.GridSpec(1, 2, wspace=0.05, hspace=0.3)
-
-ax0 = plt.subplot(spec[0])
-ax0.set_aspect('equal')
-divider = make_axes_locatable(ax0)
-cax = divider.append_axes("bottom", size="5%", pad=0.5)
-smap = salem.Map(gv, countries=False)
 x_n, y_n = smap.grid.transform(x, y,
                               crs=gv.proj)
 minv = 0
 maxv = 40
 levels = np.linspace(minv,maxv,200)
 ticks = np.linspace(minv,maxv,3)
-c = ax0.tricontourf(x_n, y_n, t, alpha_v_il, levels=levels, cmap=cmap_params_alpha, extend="both")
+c = ax2.tricontourf(x_n, y_n, t, alpha_v_il, levels=levels, cmap=cmap_params_alpha, extend="both")
 smap.set_cmap(cmap_params_alpha)
 smap.set_vmin(minv)
 smap.set_vmax(maxv)
 smap.set_extend('both')
-smap.visualize(ax=ax0, orientation='horizontal', addcbar=False)
+smap.visualize(ax=ax2, orientation='horizontal', addcbar=False)
 cbar = smap.colorbarbase(cax=cax, orientation="horizontal",
                          label='Sliding parameter \n [m$^{-1/6}$ yr$^{1/6}$ Pa$^{1/2}$]')
-at = AnchoredText('a', prop=dict(size=18), frameon=True, loc='upper right')
-ax0.add_artist(at)
+at = AnchoredText('c', prop=dict(size=18), frameon=True, loc='upper right')
+ax2.add_artist(at)
 
-ax1 = plt.subplot(spec[1])
-ax1.set_aspect('equal')
-divider = make_axes_locatable(ax1)
+ax3 = plt.subplot(spec[3])
+ax3.set_aspect('equal')
+divider = make_axes_locatable(ax3)
 cax = divider.append_axes("bottom", size="5%", pad=0.5)
 smap = salem.Map(gv, countries=False)
 x_n, y_n = smap.grid.transform(x, y,
@@ -267,21 +262,86 @@ minv = 400
 maxv = 800
 levels = np.linspace(minv,maxv,200)
 ticks = np.linspace(minv,maxv,3)
-c = ax1.tricontourf(x_n, y_n, t, beta_v_il, levels=levels, cmap=cmap_params_bglen, extend="both")
+c = ax3.tricontourf(x_n, y_n, t, beta_v_il, levels=levels, cmap=cmap_params_bglen, extend="both")
 smap.set_cmap(cmap_params_bglen)
 smap.set_vmin(minv)
 smap.set_vmax(maxv)
 smap.set_extend('both')
-smap.visualize(ax=ax1, orientation='horizontal', addcbar=False)
+smap.visualize(ax=ax3, orientation='horizontal', addcbar=False)
 cbar = smap.colorbarbase(cax=cax, orientation="horizontal",
                          label='Ice stiffness parameter \n [Pa$^{1/2}$. yr$^{1/6}$]')
-at = AnchoredText('b', prop=dict(size=18), frameon=True, loc='upper right')
-ax1.add_artist(at)
+at = AnchoredText('d', prop=dict(size=18), frameon=True, loc='upper right')
+ax3.add_artist(at)
+
+ax1.title.set_text(r'Model speed')
+ax2.title.set_text(r'Observed speed')
+ax2.title.set_text(r'$\alpha_{MEaSUREs}$')
+ax3.title.set_text(r'$\beta_{MEaSUREs}$')
+
+fig1.set_constrained_layout(True)
+path_to_plot = os.path.join(str(plot_path), 'ase_inversion' + args.plot_name +  '.png')
+plt.savefig(path_to_plot, bbox_inches='tight', dpi=150)
+
+if args.plot_domain:
+    basins = sns.color_palette("Spectral_r")
+    # Now plotting next figure
+    r=1.2
+
+    fig1 = plt.figure(figsize=(8*r, 7*r))#, constrained_layout=True)
+    spec = gridspec.GridSpec(1, 2, wspace=0.25, hspace=0.05)
+
+    ax0 = plt.subplot(spec[0])
+    ax0.set_aspect('equal')
+    smap = salem.Map(gv, countries=False)
+    x_n, y_n = smap.grid.transform(x, y,
+                                  crs=gv.proj)
+
+    smap.set_shapefile(shp_sel.loc[[63]], linewidth=2, edgecolor=basins[0], facecolor=basins[0], alpha=0.5)
+    smap.set_shapefile(shp_sel.loc[[64, 138]], linewidth=2, edgecolor=basins[1], facecolor=basins[1], alpha=0.5)
+    smap.set_shapefile(shp_sel.loc[[62, 137, 139]], linewidth=2, edgecolor=basins[2], facecolor=basins[2], alpha=0.5)
+    smap.set_lonlat_contours(add_ytick_labels=False, xinterval=10, yinterval=2, linewidths=1.5,
+                              linestyles='-', colors='grey', add_tick_labels=False)
+    smap.set_scale_bar(location=(0.87, 0.04), add_bbox=True)
+
+    ax0.triplot(x_n, y_n, trim.triangles, '-', color='black', lw=0.2)
+    smap.visualize(ax=ax0, orientation='horizontal', addcbar=True)
+    at = AnchoredText('a', prop=dict(size=18), frameon=True, loc='upper left')
+    ax0.add_artist(at)
 
 
-ax0.title.set_text(r'$\alpha_{MEaSUREs}$')
-ax1.title.set_text(r'$\beta_{MEaSUREs}$')
+    ax1 = plt.subplot(spec[1])
+    ax1.set_aspect('equal')
+    divider = make_axes_locatable(ax1)
+    cax = divider.append_axes("bottom", size="5%", pad=0.5)
+    smap = salem.Map(gv, countries=False)
+    x_n, y_n = smap.grid.transform(x, y,
+                                  crs=gv.proj)
+    minv = 0
+    maxv = 800
+    levels = np.linspace(minv,maxv,200)
+    ticks = np.linspace(minv,maxv,3)
+    c = ax1.tricontourf(x_n, y_n, t, uv_obs_live, levels = levels, cmap=cmap_vel, extend="both")
+    smap.set_vmin(minv)
+    smap.set_vmax(maxv)
+    smap.set_extend('both')
+    smap.set_cmap(cmap_vel)
 
-plt.tight_layout()
-plt.savefig(os.path.join(plot_path, 'ase_inversion.png'),
-            bbox_inches='tight', dpi=150)
+    for g, geo in enumerate(data.geometry):
+        smap.set_geometry(data.loc[g].geometry,
+                          linewidth=2.0,
+                          color=sns.xkcd_rgb["black"], crs=gv.proj)
+
+    smap.set_lonlat_contours(add_ytick_labels=False, xinterval=10, yinterval=2, linewidths=1.5,
+                              linestyles='-', colors='grey', add_tick_labels=False)
+    smap.visualize(ax=ax1, orientation='horizontal', addcbar=False)
+    cbar = smap.colorbarbase(cax=cax, orientation="horizontal",
+                             label='Velocity [m/yr]')
+    at = AnchoredText('b', prop=dict(size=18), frameon=True, loc='upper left')
+    ax1.add_artist(at)
+
+    ax0.title.set_text('Model domain')
+    ax1.title.set_text('MEaSUREsv2 average 1996-2016')
+
+    fig1.set_constrained_layout(True)
+    path_to_plot = os.path.join(str(plot_path), 'ase_input_data.png')
+    plt.savefig(path_to_plot, bbox_inches='tight', dpi=150)

--- a/scripts/plotting_scripts/plot_intro_figure.py
+++ b/scripts/plotting_scripts/plot_intro_figure.py
@@ -182,8 +182,8 @@ r=1.2
 tick_options = {'axis':'both','which':'both','bottom':False,
      'top':False,'left':False,'right':False,'labelleft':False, 'labelbottom':False}
 
-fig1 = plt.figure(figsize=(16*r, 6*r))#, constrained_layout=True)
-spec = gridspec.GridSpec(1, 2, wspace=0.05)
+fig1 = plt.figure(figsize=(10*r, 12*r))#, constrained_layout=True)
+spec = gridspec.GridSpec(2, 2, wspace=0.05, hspace=0.3)
 
 ax0 = plt.subplot(spec[0])
 divider = make_axes_locatable(ax0)
@@ -216,7 +216,7 @@ divider = make_axes_locatable(ax1)
 cax = divider.append_axes("bottom", size="5%", pad=0.5)
 smap = salem.Map(gv, countries=False)
 
-c = ax1.tricontourf(x_n, y_n, t, uv_obs_live, levels = levels, cmap='viridis', extend="both")
+c = ax1.tricontourf(x_n, y_n, t, uv_live, levels = levels, cmap='viridis', extend="both")
 smap.set_lonlat_contours(xinterval=2.0, yinterval=1.0, add_tick_labels=True, linewidths=1.5)
 smap.set_vmin(minv)
 smap.set_vmax(maxv)
@@ -284,6 +284,7 @@ plt.savefig(path_to_plot, bbox_inches='tight', dpi=150)
 
 if args.plot_domain:
     basins = sns.color_palette("Spectral_r")
+    cmap_vel=sns.color_palette("Spectral_r", as_cmap=True)
     # Now plotting next figure
     r=1.2
 
@@ -320,7 +321,7 @@ if args.plot_domain:
     maxv = 800
     levels = np.linspace(minv,maxv,200)
     ticks = np.linspace(minv,maxv,3)
-    c = ax1.tricontourf(x_n, y_n, t, uv_obs_live, levels = levels, cmap=cmap_vel, extend="both")
+    c = ax1.tricontourf(x_n, y_n, t, uv_live, levels = levels, cmap=cmap_vel, extend="both")
     smap.set_vmin(minv)
     smap.set_vmax(maxv)
     smap.set_extend('both')

--- a/scripts/plotting_scripts/plot_linearity_all.py
+++ b/scripts/plotting_scripts/plot_linearity_all.py
@@ -1,0 +1,170 @@
+import sys
+import matplotlib.pyplot as plt
+import seaborn as sns
+import os
+import numpy as np
+import glob
+import pandas as pd
+
+import matplotlib.ticker as ticker
+from matplotlib import rcParams
+from configobj import ConfigObj
+import argparse
+
+# Load configuration file for more order in paths
+parser = argparse.ArgumentParser()
+parser.add_argument("-conf",
+                    type=str,
+                    default="../../../config.ini",
+                    help="pass config file")
+
+args = parser.parse_args()
+config_file = args.conf
+config = ConfigObj(os.path.expanduser(config_file))
+# Define main repository path
+MAIN_PATH = config['main_path']
+
+# Paths to output data
+sub_plot_dir = args.sub_plot_dir
+plot_path = os.path.join(MAIN_PATH, 'plots/'+ sub_plot_dir)
+if not os.path.exists(plot_path):
+    os.makedirs(plot_path)
+
+sens_file_paths = glob.glob(os.path.join(plot_path, "*.csv"))
+
+dfoa = pd.read_csv(sens_file_paths[1])
+dsoa = pd.read_csv(sens_file_paths[2])
+dsoa_syn = pd.read_csv(sens_file_paths[-1])
+
+rcParams['axes.labelsize'] = 16
+rcParams['xtick.labelsize'] = 16
+rcParams['ytick.labelsize'] = 16
+rcParams['legend.fontsize'] = 14
+rcParams['axes.titlesize'] = 14
+rcParams['axes.titlesize'] = 14
+rcParams['font.size'] = 14
+
+label_foa = [r'$\Delta$ ($Q^{M}_{T}$ - $Q^{I}_{T}$)',
+             r'$\frac{\partial Q_{M}}{\partial \alpha_{M}} \cdot (\alpha_{M} - \alpha_{I})$ +' + '\n' +
+             r'$\frac{\partial Q_{M}}{\partial \beta_{M}} \cdot (\beta_{M} - \beta_{I})$']
+
+label_soa = [r'$\Delta$ $Q^{M}_{T}$ - $Q^{I}_{T}$',
+             r'$\frac{\partial Q_{M}}{\partial U_{M}} \cdot (u_{M} - u_{I})$' + ' + ' + '\n' +
+             r'$\frac{\partial Q_{M}}{\partial V_{M}} \cdot (v_{M} - v_{I})$']
+
+label_soa_syn = [r'$\Delta$ $Q^{M}_{T}$ - $Q^{S}_{T}$',
+             r'$\frac{\partial Q_{M}}{\partial U_{M}} \cdot (u_{M} - u_{S})$' + ' + ' + '\n' +
+             r'$\frac{\partial Q_{M}}{\partial V_{M}} \cdot (v_{M} - v_{S})$']
+
+r = 0.9
+color_palette = sns.color_palette("deep")
+
+# Create figure and axes in a 2x4 grid
+fig, axes = plt.subplots(nrows=3, ncols=4, figsize=(16 * r, 12 * r))
+
+# Axis limits
+xlim = (0, 40)
+ylim = (-0.5e12, 2.5e12)
+
+# Axis ticks
+xticks = np.arange(0, 41, 10)
+yticks = np.arange(-0.5e12, 2.51e12, 0.5e12)
+
+# Plot manually on each axis (replace with your own data)
+delta_qoi = dfoa['delta_VAF_measures_all'] - dfoa['delta_VAF_itslive_all']
+dot_product = dfoa['Dot_product_all']
+axes[0, 0].plot(dfoa['time'], delta_qoi, linestyle='dashed', color=color_palette[3])
+axes[0, 0].plot(dfoa['time'], dot_product, color=color_palette[1])
+axes[0, 0].set_ylabel(r'$\Delta$ $Q_{T}$ [$m^3$]')
+axes[0, 0].set_title('Full domain \n', fontsize=16)
+
+delta_qoi = dfoa['delta_VAF_measures_PIG'] - dfoa['delta_VAF_itslive_PIG']
+dot_product = dfoa['Dot_product_PIG']
+axes[0, 1].plot(dfoa['time'], delta_qoi, linestyle='dashed', color=color_palette[3])
+axes[0, 1].plot(dfoa['time'], dot_product, color=color_palette[1])
+axes[0, 1].set_title('Pine Island basin \n', fontsize=16)
+
+delta_qoi = dfoa['delta_VAF_measures_THW'] - dfoa['delta_VAF_itslive_THW']
+dot_product = dfoa['Dot_product_THW']
+axes[0, 2].plot(dfoa['time'], delta_qoi, linestyle='dashed', color=color_palette[3])
+axes[0, 2].plot(dfoa['time'], dot_product, color=color_palette[1])
+axes[0, 2].set_title('Thwaites and \n Haynes basins', fontsize=16)
+
+delta_qoi = dfoa['delta_VAF_measures_SPK'] - dfoa['delta_VAF_itslive_SPK']
+dot_product = dfoa['Dot_product_SPK']
+p1, = axes[0, 3].plot(dfoa['time'], delta_qoi, linestyle='dashed', color=color_palette[3])
+p2, = axes[0, 3].plot(dfoa['time'], dot_product, color=color_palette[1])
+axes[0, 3].set_title('Smith, Pope and \n Kohler basins', fontsize=16)
+
+axes[0, 3].legend(handles=[p1, p2],
+                  labels=label_foa,
+                  frameon=True, fontsize=14, loc='upper left')
+
+## SOA ################# plots ###################
+
+delta_qoi = dsoa['delta_VAF_measures_all'] - dsoa['delta_VAF_itslive_all']
+dot_product = dsoa['Dot_product_all']
+axes[1, 0].plot(dsoa['time'], delta_qoi, linestyle='dashed', color=color_palette[3])
+axes[1, 0].plot(dsoa['time'], dot_product, color=color_palette[2])
+axes[1, 0].set_ylabel(r'$\Delta$ $Q_{T}$ [$m^3$]')
+
+delta_qoi = dsoa['delta_VAF_measures_PIG'] - dsoa['delta_VAF_itslive_PIG']
+dot_product = dsoa['Dot_product_PIG']
+axes[1, 1].plot(dsoa['time'], delta_qoi, linestyle='dashed', color=color_palette[3])
+axes[1, 1].plot(dsoa['time'], dot_product, color=color_palette[2])
+
+delta_qoi = dsoa['delta_VAF_measures_THW'] - dsoa['delta_VAF_itslive_THW']
+dot_product = dsoa['Dot_product_THW']
+axes[1, 2].plot(dsoa['time'], delta_qoi, linestyle='dashed', color=color_palette[3])
+axes[1, 2].plot(dsoa['time'], dot_product, color=color_palette[2])
+
+delta_qoi = dsoa['delta_VAF_measures_SPK'] - dsoa['delta_VAF_itslive_SPK']
+dot_product = dsoa['Dot_product_SPK']
+p1, = axes[1, 3].plot(dsoa['time'], delta_qoi, linestyle='dashed', color=color_palette[3])
+p2, = axes[1, 3].plot(dsoa['time'], dot_product, color=color_palette[2])
+
+axes[1, 3].legend(handles=[p1, p2],
+                  labels=label_soa,
+                  frameon=True, fontsize=14, loc='upper left')
+
+###################### synthetic ###############################################
+
+delta_qoi_sin = dsoa_syn['delta_VAF_measures_all'] - dsoa_syn['delta_VAF_synthetic_all']
+dot_product_sin = dsoa_syn['Dot_product_all']
+axes[2, 0].plot(dsoa['time'], delta_qoi_sin, linestyle='dashed', color='black')
+axes[2, 0].plot(dsoa['time'], dot_product_sin, color=color_palette[4])
+axes[2, 0].set_ylabel(r'$\Delta$ $Q_{T}$ [$m^3$]')
+
+delta_qoi_sin = dsoa_syn['delta_VAF_measures_PIG'] - dsoa_syn['delta_VAF_synthetic_PIG']
+dot_product_sin = dsoa_syn['Dot_product_PIG']
+axes[2, 1].plot(dsoa['time'], delta_qoi_sin, linestyle='dashed', color='black')
+axes[2, 1].plot(dsoa['time'], dot_product_sin, color=color_palette[4])
+
+delta_qoi_sin = dsoa_syn['delta_VAF_measures_THW'] - dsoa_syn['delta_VAF_synthetic_THW']
+dot_product_sin = dsoa_syn['Dot_product_THW']
+axes[2, 2].plot(dsoa['time'], delta_qoi_sin, linestyle='dashed', color='black')
+axes[2, 2].plot(dsoa['time'], dot_product_sin, color=color_palette[4])
+
+delta_qoi_sin = dsoa_syn['delta_VAF_measures_SPK'] - dsoa_syn['delta_VAF_synthetic_SPK']
+dot_product_sin = dsoa_syn['Dot_product_SPK']
+p1, = axes[2, 3].plot(dsoa['time'], delta_qoi_sin, linestyle='dashed', color='black')
+p2, = axes[2, 3].plot(dsoa['time'], dot_product_sin, color=color_palette[4])
+
+axes[2, 3].legend(handles=[p1, p2],
+                  labels=label_soa_syn,
+                  frameon=True, fontsize=14, loc='upper left')
+
+# Apply axis settings to all
+for ax in axes.flat:
+    ax.set_xlim(xlim)
+    ax.set_ylim(ylim)
+    ax.set_xticks(xticks)
+    ax.set_yticks(yticks)
+    ax.grid(True)
+    ax.set_xlabel('Years')
+
+
+file_plot_name = 'results_linearity_ALL.png'
+
+fig_save_path = os.path.join(plot_path, file_plot_name)
+plt.savefig(fig_save_path, bbox_inches='tight', dpi=150)

--- a/scripts/plotting_scripts/plot_linearity_all.py
+++ b/scripts/plotting_scripts/plot_linearity_all.py
@@ -17,6 +17,10 @@ parser.add_argument("-conf",
                     type=str,
                     default="../../../config.ini",
                     help="pass config file")
+parser.add_argument("-sub_plot_dir",
+                    type=str,
+                    default="temp",
+                    help="pass sub plot directory to store csv file with output")
 
 args = parser.parse_args()
 config_file = args.conf

--- a/scripts/plotting_scripts/plot_linearity_all.py
+++ b/scripts/plotting_scripts/plot_linearity_all.py
@@ -138,25 +138,46 @@ dot_product_sin = dsoa_syn['Dot_product_all']
 axes[2, 0].plot(dsoa['time'], delta_qoi_sin, linestyle='dashed', color='black')
 axes[2, 0].plot(dsoa['time'], dot_product_sin, color=color_palette[4])
 axes[2, 0].set_ylabel(r'$\Delta$ $Q_{T}$ [$m^3$]')
+axes[2, 0].set_xlabel('Years')
 
 delta_qoi_sin = dsoa_syn['delta_VAF_measures_PIG'] - dsoa_syn['delta_VAF_synthetic_PIG']
 dot_product_sin = dsoa_syn['Dot_product_PIG']
 axes[2, 1].plot(dsoa['time'], delta_qoi_sin, linestyle='dashed', color='black')
 axes[2, 1].plot(dsoa['time'], dot_product_sin, color=color_palette[4])
+axes[2, 1].set_xlabel('Years')
 
 delta_qoi_sin = dsoa_syn['delta_VAF_measures_THW'] - dsoa_syn['delta_VAF_synthetic_THW']
 dot_product_sin = dsoa_syn['Dot_product_THW']
 axes[2, 2].plot(dsoa['time'], delta_qoi_sin, linestyle='dashed', color='black')
 axes[2, 2].plot(dsoa['time'], dot_product_sin, color=color_palette[4])
+axes[2, 2].set_xlabel('Years')
 
 delta_qoi_sin = dsoa_syn['delta_VAF_measures_SPK'] - dsoa_syn['delta_VAF_synthetic_SPK']
 dot_product_sin = dsoa_syn['Dot_product_SPK']
 p1, = axes[2, 3].plot(dsoa['time'], delta_qoi_sin, linestyle='dashed', color='black')
 p2, = axes[2, 3].plot(dsoa['time'], dot_product_sin, color=color_palette[4])
+axes[2, 3].set_xlabel('Years')
 
 axes[2, 3].legend(handles=[p1, p2],
                   labels=label_soa_syn,
                   frameon=True, fontsize=14, loc='upper left')
+
+# Hide axis labels and ticks except bottom row and rightmost column
+for row in range(3):
+    for col in range(4):
+        ax = axes[row, col]
+
+        # Remove x-axis labels and ticks unless on bottom row
+        if row != 2:
+            ax.set_xlabel('')
+            ax.set_xticklabels([])
+            ax.set_xticks([])
+
+        # Remove y-axis labels and ticks unless on rightmost column
+        if col != 0:
+            ax.set_ylabel('')
+            ax.set_yticklabels([])
+            ax.set_yticks([])
 
 # Apply axis settings to all
 for ax in axes.flat:
@@ -165,8 +186,6 @@ for ax in axes.flat:
     ax.set_xticks(xticks)
     ax.set_yticks(yticks)
     ax.grid(True)
-    ax.set_xlabel('Years')
-
 
 file_plot_name = 'results_linearity_ALL.png'
 


### PR DESCRIPTION
Another big commit. 

**New scripts:**
scripts/plotting_scripts/centreline_plot.py
scripts/plotting_scripts/plot_linearity_all.py

These scripts are used to:
- Plot linearity tests on various simulations
- Visualize QoI sensitivities along a centreline transect for each main ice stream

**Updated scripts:**
scripts/plotting_scripts/plot_ASE_params_sens_per_icestream.py
scripts/plotting_scripts/plot_ASE_vel_sens_per_icestream.py

Changes include:
- Reading the model grounding line from a shapefile output
- Adding grounding line overlays to the sensitivity maps

Main change: `scripts/plotting_scripts/plot_ASE_vel_sens_per_icestream.py` -> lines [#L185-L266](https://github.com/bearecinos/ASE_fenics_ice_exp/blob/6850f015ff36393e7e2384e3c6ccbe744ee12e89/scripts/plotting_scripts/plot_ASE_vel_sens_per_icestream.py#L185-L266) 
- Model output is regridded to a regular grid matching the resolution of the ice velocity dataset.

